### PR TITLE
Fix memory-safety bugs found in pre-release security audit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,3 +34,17 @@ jobs:
         name: Farray1 Tests
         path: build/tests_results/farray1.xml
         reporter: java-junit
+
+  sanitize:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    # alignment checking is disabled on purpose: the algorithm packs pointers
+    # into the array via #pragma pack(1), so unaligned loads are by design
+    - name: Build with ASan + UBSan
+      run: g++ -std=c++14 -O1 -g -fsanitize=address,undefined -fno-sanitize=alignment -fno-sanitize-recover=all tests/tests_farray1.cpp tests/test_header_first.cpp -o farray1_tests_san
+
+    - name: Run tests under sanitizers
+      run: ./farray1_tests_san

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,5 +4,5 @@ project(Farray)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_FLAGS -O2)
 
-add_executable(farray1_tests tests/tests_farray1.cpp)
+add_executable(farray1_tests tests/tests_farray1.cpp tests/test_header_first.cpp)
 add_executable(times timings/times_farray1.cpp)

--- a/include/farray1.hpp
+++ b/include/farray1.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 
 /*
 Implementation of "In-Place Initializable Arrays" paper - https://arxiv.org/abs/1709.08900
@@ -169,6 +171,7 @@ namespace Farray1Direct {
     // r <= 5
     template<typename T, typename ptr_size = size_t>
     T read(const T* A, size_t n, size_t index, bool flag = false) {
+        if (n == 0) return T();
         defines::ArrayHelper<T,ptr_size> h(A, n, flag);
         index %= n;
 
@@ -195,6 +198,7 @@ namespace Farray1Direct {
     //     first_write: r <= 13, w <= 5HB+7
     template<typename T, typename ptr_size = size_t>
     bool write(T* A, size_t n, size_t index, const T& v, bool flag = false) {
+        if (n == 0) return flag;
         defines::ArrayHelper<T,ptr_size> h(A, n, flag);
         index %= n;
 
@@ -249,6 +253,7 @@ namespace Farray1Direct {
     size_t writtenSize(T* A, size_t n, bool flag = false) {
         if (flag) return n;
         defines::ArrayHelper<T,ptr_size> h(A, n);
+        if (h.numBlocks() == 0) return n;   // no blocks - every cell is stored directly
         return h.lastP().b * defines::blockSize<T,ptr_size>() + (n - h.blocksEnd());
     }
 
@@ -267,8 +272,8 @@ namespace Farray1Direct {
             size_t belowB = writtenSize<T,ptr_size>(A, n, flag) - (n - afterLastBlock);
             if (i < n && i == belowB) i = afterLastBlock;
         }
-        bool operator==(class iterator& o) { return i == o.i; }
-        bool operator!=(class iterator& o) { return !(*this == o); }
+        bool operator==(const iterator& o) const { return i == o.i; }
+        bool operator!=(const iterator& o) const { return !(*this == o); }
         // r == 3
         size_t operator*() {
             defines::ArrayHelper<T,ptr_size> ah(A, n, flag);
@@ -277,7 +282,10 @@ namespace Farray1Direct {
             ptr_size bi = i/bs, k;
 
             size_t index = i;
-            if (!flag && ah.chainedTo(bi, k))
+            // tail cells (past the last full block) are stored directly and are
+            // never chained - calling chainedTo there would read the user's tail
+            // data as a chain pointer (and past the end of the array).
+            if (!flag && i < ah.blocksEnd() && ah.chainedTo(bi, k))
                 index = k  * bs + mod;
             return index;
         }
@@ -308,6 +316,11 @@ class Farray1 {
 public:
     const size_t n;
     Farray1(T* A, size_t n, const T& def) : A(A), n(n), flag(true), malloced(false) { fill(def); }
+
+    // copying would alias the (possibly owned) buffer and double-delete it
+    Farray1(const Farray1&) = delete;
+    Farray1& operator=(const Farray1&) = delete;
+    Farray1(Farray1&& o) noexcept : A(o.A), flag(o.flag), malloced(o.malloced), n(o.n) { o.A = nullptr; }
 
 #ifndef FARRAY1_NO_DYNAMIC_ALLOCATIONS
     Farray1(size_t n, const T& def) : A(new T[n]), n(n), flag(true), malloced(true) { fill(def); }

--- a/include/farray1.hpp
+++ b/include/farray1.hpp
@@ -69,7 +69,7 @@ namespace Farray1Direct {
 
             ptrBdef<T,ptr_size>& lastP() { return A[numBlocks()-1].first.p; }
             const ptrBdef<T,ptr_size>& lastP() const { return A[numBlocks()-1].first.p; }
-            void expendB() { flag = ((++lastP().b) == numBlocks()); }  // r == 1, w == 1
+            void expendB() { flag = ((size_t)(++lastP().b) == numBlocks()); }  // r == 1, w == 1
             void fillBottom(const T& v) { auto& p = lastP(); p.b = 0; p.def = v; }   // w == 2
 
             ptr_size setIndices(size_t i, size_t& mod, bool& first) const {
@@ -85,7 +85,7 @@ namespace Farray1Direct {
             bool chainedTo(ptr_size i, ptr_size& k) const {
                 k = A[i].first.p.ptr;
                 const auto& b = lastP().b;
-                return (k != i) && (k < numBlocks()) && ((i<b) ^ (k<b))
+                return (k != i) && ((size_t)k < numBlocks()) && ((i<b) ^ (k<b))
                     && (A[k].first.p.ptr == i);
             }
             // w == 2
@@ -101,13 +101,13 @@ namespace Farray1Direct {
             }
             // r <= 2, w <= HB+1
             void firstHalfInitBlock(ptr_size i, const T& v) {
-                for (int t = 0; t < halfBlockSize<T,ptr_size>(); t++)
+                for (size_t t = 0; t < halfBlockSize<T,ptr_size>(); t++)
                     A[i].first.v[t] = v;
                 breakChain(i);
             }
             // w == HB
             void secondHalfInitBlock(ptr_size i, const T& v) {
-                for (int t = 0; t < halfBlockSize<T,ptr_size>(); t++)
+                for (size_t t = 0; t < halfBlockSize<T,ptr_size>(); t++)
                     A[i].second.v[t] = v;
             }
 
@@ -315,7 +315,7 @@ class Farray1 {
     const bool malloced;
 public:
     const size_t n;
-    Farray1(T* A, size_t n, const T& def) : A(A), n(n), flag(true), malloced(false) { fill(def); }
+    Farray1(T* A, size_t n, const T& def) : A(A), flag(true), malloced(false), n(n) { fill(def); }
 
     // copying would alias the (possibly owned) buffer and double-delete it
     Farray1(const Farray1&) = delete;
@@ -323,7 +323,7 @@ public:
     Farray1(Farray1&& o) noexcept : A(o.A), flag(o.flag), malloced(o.malloced), n(o.n) { o.A = nullptr; }
 
 #ifndef FARRAY1_NO_DYNAMIC_ALLOCATIONS
-    Farray1(size_t n, const T& def) : A(new T[n]), n(n), flag(true), malloced(true) { fill(def); }
+    Farray1(size_t n, const T& def) : A(new T[n]), flag(true), malloced(true), n(n) { fill(def); }
     ~Farray1() { if (malloced) delete[] A; }
 #endif
 

--- a/tests/test_header_first.cpp
+++ b/tests/test_header_first.cpp
@@ -1,0 +1,4 @@
+// Compile-only check: farray1.hpp must be self-contained, i.e. compile as the
+// very first include of a translation unit (the README tells users to just
+// download and include it).
+#include "../include/farray1.hpp"

--- a/tests/tests_farray1.cpp
+++ b/tests/tests_farray1.cpp
@@ -27,7 +27,7 @@ using namespace std::chrono;
 template<typename T, typename ptr_size1, typename ptr_size2>
 bool verify_all_four_arrays_equal(T *regular_array, const Farray1<T, ptr_size1> &farray1_ptr_size1,
                                   const Farray1<T, ptr_size2> &farray2_ptr_size2, T *farray3_using_Farray1Direct,
-                                  int farray3_n, bool farray3_flag) {
+                                  size_t farray3_n, bool farray3_flag) {
     for (size_t i = 0; i < farray3_n; i++) {
         if (!(regular_array[i] == Farray1Direct::read(farray3_using_Farray1Direct, farray3_n, i, farray3_flag) &&
               regular_array[i] == farray1_ptr_size1[i] && regular_array[i] == farray2_ptr_size2[i] &&
@@ -88,15 +88,15 @@ bool stress_test(size_t array_size) {
 
     vector<char> actions;
     actions.reserve(read_operations + write_operations + init_operations);
-    for (int i = 0; i < read_operations; i++) actions.emplace_back('R');
-    for (int i = 0; i < write_operations; i++) actions.emplace_back('W');
-    for (int i = 0; i < init_operations; i++) actions.emplace_back('F');
+    for (size_t i = 0; i < read_operations; i++) actions.emplace_back('R');
+    for (size_t i = 0; i < write_operations; i++) actions.emplace_back('W');
+    for (size_t i = 0; i < init_operations; i++) actions.emplace_back('F');
     auto rng = default_random_engine{};
     shuffle(begin(actions), end(actions), rng);
 
     unique_ptr<T[]> arr_owner(new T[array_size]);
     T *arr = arr_owner.get();
-    for (int u = 0; u < array_size; u++) arr[u] = def;
+    for (size_t u = 0; u < array_size; u++) arr[u] = def;
 
     if (!verify_all_four_arrays_equal<T>(arr, farr1, farr2, A, array_size, flag)) {
         cout << "Just initialized! def = " << def << "." << endl;
@@ -111,7 +111,7 @@ bool stress_test(size_t array_size) {
         if (op == 'F') {
             lastF = count;
             if (rand() & 1) def = v;
-            for (int u = 0; u < array_size; u++) arr[u] = def;
+            for (size_t u = 0; u < array_size; u++) arr[u] = def;
             flag = Farray1Direct::fill(A, array_size, def);
             farr1.fill(def);
             farr2 = def;
@@ -149,11 +149,11 @@ bool verify_farray_iterator_goes_through_the_exact_cells_the_algorithm_initializ
     vector<bool> reallyWritten(farray.n, false);
     int bsize = Farray1Direct::defines::blockSize<T, ptr_size>();
 
-    for (int j = Farray1Direct::defines::ArrayHelper<T, ptr_size>::blocksEnd(farray.n); j < farray.n; j++) {
+    for (size_t j = Farray1Direct::defines::ArrayHelper<T, ptr_size>::blocksEnd(farray.n); j < farray.n; j++) {
         isWritten[j] = true;
     }
     for (auto i: written_indices) {
-        if (i >= Farray1Direct::defines::ArrayHelper<T, ptr_size>::blocksEnd(farray.n)) {
+        if ((size_t)i >= Farray1Direct::defines::ArrayHelper<T, ptr_size>::blocksEnd(farray.n)) {
             continue;
         }
         for (int j = (i / bsize) * bsize; j < (i / bsize + 1) * bsize; j++) {
@@ -163,7 +163,7 @@ bool verify_farray_iterator_goes_through_the_exact_cells_the_algorithm_initializ
 
     for (size_t i: farray) reallyWritten[i] = true;
 
-    for (int i = 0; i < farray.n; i++) {
+    for (size_t i = 0; i < farray.n; i++) {
         if (isWritten[i] != reallyWritten[i]) {
             cout << "isWritten[" << i << "] = " << isWritten[i] << ", but reallyWritten[" << i << "] = "
                  << reallyWritten[i] << "." << endl;
@@ -198,9 +198,9 @@ bool iterator_indices_test(int array_size) {
 
     vector<char> actions;
     actions.reserve(read_operations + write_operations + init_operations);
-    for (int i = 0; i < read_operations; i++) actions.emplace_back('R');
-    for (int i = 0; i < write_operations; i++) actions.emplace_back('W');
-    for (int i = 0; i < init_operations; i++) actions.emplace_back('F');
+    for (size_t i = 0; i < read_operations; i++) actions.emplace_back('R');
+    for (size_t i = 0; i < write_operations; i++) actions.emplace_back('W');
+    for (size_t i = 0; i < init_operations; i++) actions.emplace_back('F');
     auto rng = default_random_engine{};
     shuffle(begin(actions), end(actions), rng);
 
@@ -225,6 +225,7 @@ bool iterator_indices_test(int array_size) {
             written_indices.push_back(i);
         } else {
             T temp = farr[i];
+            (void)temp;
         }
 
         if (!verify_farray_iterator_goes_through_the_exact_cells_the_algorithm_initialize<T, ptr_size>

--- a/tests/tests_farray1.cpp
+++ b/tests/tests_farray1.cpp
@@ -9,6 +9,8 @@
 #include <iomanip>
 #include <iostream>
 #include <chrono>
+#include <memory>
+#include <type_traits>
 
 #include "../include/farray1.hpp"
 #include "test_classes.hpp"
@@ -79,7 +81,8 @@ bool stress_test(size_t array_size) {
     T def = rnd();
     auto farr1 = Farray1<T, ptr_size1>(array_size, def);
     auto farr2 = Farray1<T, ptr_size2>(array_size, def);
-    T *A = new T[array_size];
+    unique_ptr<T[]> A_owner(new T[array_size]);
+    T *A = A_owner.get();
     bool flag = Farray1Direct::fill(A, array_size, def);
 
     vector<char> actions;
@@ -90,7 +93,8 @@ bool stress_test(size_t array_size) {
     auto rng = default_random_engine{};
     shuffle(begin(actions), end(actions), rng);
 
-    auto arr = new T[array_size];
+    unique_ptr<T[]> arr_owner(new T[array_size]);
+    T *arr = arr_owner.get();
     for (int u = 0; u < array_size; u++) arr[u] = def;
 
     if (!verify_all_four_arrays_equal<T>(arr, farr1, farr2, A, array_size, flag)) {
@@ -231,6 +235,53 @@ bool iterator_indices_test(int array_size) {
     }
 
     return true;
+}
+
+
+TEST_CASE("Farray1 cannot be copied (copying would double-delete the buffer)", "[regression]") {
+    REQUIRE_FALSE(std::is_copy_constructible<Farray1<int>>::value);
+    REQUIRE_FALSE(std::is_copy_assignable<Farray1<int>>::value);
+    REQUIRE(std::is_move_constructible<Farray1<int>>::value);
+}
+
+
+TEST_CASE("read/write on a size-0 array don't divide by zero", "[regression]") {
+    int dummy[1] = {42};
+    REQUIRE(Farray1Direct::read(dummy, 0, 0) == 0);
+    REQUIRE_FALSE(Farray1Direct::write(dummy, 0, 0, 7));
+    REQUIRE(dummy[0] == 42);
+}
+
+
+TEST_CASE("writtenSize handles flag=false with fewer elements than one block", "[regression]") {
+    // blockSize<uint64_t,size_t>() == 6 > 4, so there are no blocks at all
+    uint64_t small[4] = {1, 2, 3, 4};
+    REQUIRE(Farray1Direct::writtenSize(small, 4, false) == 4);
+}
+
+
+TEST_CASE("iterator maps tail indices to themselves (tail data is not a chain pointer)", "[regression]") {
+    // blockSize<uint64_t,size_t>() == 6; n=13 -> blocks {0,1}, tail {12}.
+    // Writing 2 at index 0 and 0 at index 12 used to make the iterator treat the
+    // tail value as a chain from block 2 to block 0, yielding index 0 instead of 12.
+    Farray1<uint64_t> f(13, 99);
+    f.write(0, 2);
+    f.write(12, 0);
+    vector<size_t> seen;
+    for (size_t i : f) seen.push_back(i);
+    REQUIRE(count(seen.begin(), seen.end(), (size_t)0) == 1);
+    REQUIRE(count(seen.begin(), seen.end(), (size_t)12) == 1);
+}
+
+
+TEST_CASE("explicit iteration with rvalue end() compiles and matches range-for", "[regression]") {
+    Farray1<int> f(100, 1);
+    f.write(5, 7);
+    size_t explicit_count = 0;
+    for (auto it = f.begin(); it != f.end(); ++it) explicit_count++;
+    size_t range_count = 0;
+    for (size_t i : f) { (void)i; range_count++; }
+    REQUIRE(explicit_count == range_count);
 }
 
 

--- a/tests/tests_farray1.cpp
+++ b/tests/tests_farray1.cpp
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <memory>
 #include <type_traits>
+#include <utility>
 
 #include "../include/farray1.hpp"
 #include "test_classes.hpp"
@@ -242,6 +243,28 @@ TEST_CASE("Farray1 cannot be copied (copying would double-delete the buffer)", "
     REQUIRE_FALSE(std::is_copy_constructible<Farray1<int>>::value);
     REQUIRE_FALSE(std::is_copy_assignable<Farray1<int>>::value);
     REQUIRE(std::is_move_constructible<Farray1<int>>::value);
+}
+
+
+TEST_CASE("moved-from Farray1 releases ownership (no double-free)", "[regression]") {
+    Farray1<int> a(50, 7);
+    a.write(3, 9);
+    Farray1<int> b(std::move(a));
+    REQUIRE(b.read(3) == 9);
+    REQUIRE(b.read(4) == 7);
+    REQUIRE(b.n == 50);
+    // 'a' is destroyed at scope exit; it must not delete the buffer 'b' now owns
+}
+
+
+TEST_CASE("size-0 Farray1 is safe to construct, access and iterate", "[regression]") {
+    Farray1<int> f(0, 5);
+    REQUIRE(f.read(0) == 0);
+    f.write(0, 7);              // no-op, must not crash
+    REQUIRE(f.writtenSize() == 0);
+    size_t iterated = 0;
+    for (size_t i : f) { (void)i; iterated++; }
+    REQUIRE(iterated == 0);
 }
 
 


### PR DESCRIPTION
## Summary

A pre-release audit of `farray1.hpp` (manual review + ASan/UBSan) found four confirmed bugs. The core fill/read/write algorithm was verified clean — all of these are in the surrounding API. Every fix has a regression test, and every regression test demonstrably fails (or fails to compile) against the pre-fix header — see TDD evidence below.

### Fixes

1. **Double-free / use-after-free on copy** — `Farray1` owns a raw pointer (when self-allocated) but had no copy constructor, so the implicit memberwise copy aliased the buffer: `void f(Farray1<int> x); f(a);` compiled silently and corrupted the heap. Copy ctor/assignment are now `= delete`d and a move constructor is provided (needed for `auto a = Farray1<T>(...)` in C++14; moved-from object releases ownership).

2. **Iterator returned wrong indices / read out of bounds on tail cells** — `operator*` called `chainedTo()` for indices past the last full block, interpreting *user tail data* as a chain pointer. With legal writes (`f.write(0, 2); f.write(12, 0)` on a 13-element `uint64_t` array) iteration yielded `0 1 2 3 4 5 0` instead of `0 1 2 3 4 5 12`. When the tail was shorter than `sizeof(ptr_size)` the same call also read past the end of the allocation — this reproduced in the **existing** iterator tests under ASan (e.g. type X, size 15). Tail indices now map to themselves without touching chain logic.

3. **Division by zero for n == 0** — `read`/`write` did `index %= n` unconditionally (SIGFPE). `read` now returns `T()` and `write` is a no-op returning the flag unchanged. `writtenSize` similarly indexed `A[numBlocks()-1]` with zero blocks when given `flag=false`; it now returns `n`. Note: the `read` guard adds a DefaultConstructible requirement on `T` (only when `read` is used); all tested types qualify.

4. **Header was not self-contained** — `farray1.hpp` used `size_t` without including `<cstddef>`, so `#include "farray1.hpp"` as the first include failed with ~100 errors (the README's advertised usage). Added the include plus a compile-only TU (`tests/test_header_first.cpp`) so it can't regress.

Also: iterator `operator==`/`!=` are now `const` and take `const&`, so explicit `it != f.end()` iteration compiles (previously only range-`for` worked, by accident of desugaring).

### CI

Added a `sanitize` job (ASan + UBSan, `-fno-sanitize=alignment` since unaligned access is inherent to the `#pragma pack(1)` design). The pre-fix iterator OOB fired in the *existing* test suite under ASan, so this gate alone would have caught bug 2. Fixed the scratch-array leaks in `stress_test` (test harness only) so LeakSanitizer runs clean.

## TDD evidence (R1)

### Before (FAIL — new regression tests run against the pre-fix header from HEAD~1, ASan+UBSan build):

```
##### COMPILE: header-first TU (old header) #####
tests/../include/farray1.hpp:44:19: error: 'size_t' does not name a type
   44 |         constexpr size_t halfBlockSize() {

##### COMPILE: explicit it != f.end() (old header) #####
error: cannot bind non-const lvalue reference of type 'Farray1Direct::iterator<int, long unsigned int>&'
       to an rvalue of type 'Farray1Direct::iterator<int, long unsigned int>'
    3 | int main() { Farray1<int> f(100, 1); for (auto it = f.begin(); it != f.end(); ++it) {} }

##### RUN: Farray1 cannot be copied (copying would double-delete the buffer) #####
tests/tests_farray1.cpp:243: FAILED:
  REQUIRE_FALSE( std::is_copy_constructible<Farray1<int>>::value )
with expansion:  !true

##### RUN: moved-from Farray1 releases ownership (no double-free) #####
==642==ERROR: AddressSanitizer: attempting double-free on 0x511000000b80 in thread T0

##### RUN: size-0 Farray1 is safe to construct, access and iterate #####
tests/../include/farray1.hpp:173:15: runtime error: division by zero
==687==ERROR: AddressSanitizer: FPE on unknown address 0x03e8000002af

##### RUN: read/write on a size-0 array don't divide by zero #####
tests/../include/farray1.hpp:173:15: runtime error: division by zero
==655==ERROR: AddressSanitizer: FPE on unknown address 0x03e80000028f

##### RUN: writtenSize handles flag=false with fewer elements than one block #####
==659==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffdf4740458

##### RUN: iterator maps tail indices to themselves (tail data is not a chain pointer) #####
tests/tests_farray1.cpp:295: FAILED:
  REQUIRE( count(seen.begin(), seen.end(), (size_t)0) == 1 )
with expansion:  2 == 1
```

### After (all PASS — same tests against the fixed header, same ASan+UBSan build):

```
$ ./farray1_tests_san "[regression]"
All tests passed (16 assertions in 7 test cases)

$ ./farray1_tests_san          # full suite
All tests passed (538 assertions in 65 test cases)
```

## Integration evidence (R2)

Iterator behavior before/after on a 13-element `uint64_t` array after `write(0,2); write(12,0)`:

```
before:  iteration indices: 0 1 2 3 4 5 0     <- index 12 lost, 0 visited twice
after:   iteration indices: 0 1 2 3 4 5 12    <- correct
```

Full suite at -O2 (the CI configuration): `All tests passed (538 assertions in 65 test cases)`.
Full suite under ASan+UBSan: clean — 0 reports, 0 leaks (previously: heap-buffer-overflow in the iterator tests + 31 MB leaked by the test harness).

## Self-check

| Check | Status |
| --- | --- |
| Tests-first evidence (FAIL log against pre-fix header + PASS log) | pass |
| Integration evidence (behavioral before/after + sanitizer runs) | pass |
| Every touched logic path has a new regression test | pass |
| API compatibility (existing tests, timings target, README snippets compile unchanged) | pass |
| Zero new warnings (`-Wall -Wextra` delta vs parent commit) | pass |
| CI gate added that would have caught the worst bug | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)